### PR TITLE
Remove use of pathfinder-ui

### DIFF
--- a/app/middleware/index.js
+++ b/app/middleware/index.js
@@ -6,7 +6,6 @@ const favicon = require('serve-favicon');
 const logger = require('morgan');
 const bodyParser = require('body-parser');
 const cors = require('cors');
-const pathfinderUI = require('pathfinder-ui')
 
 const loader = require('lib/wiring/loader');
 
@@ -22,11 +21,6 @@ const before = (app) => {
   app.use(logger('dev'));
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));
-  // added to find express routes
-  app.use('/pathfinder', function(req, res, next) {
-    pathfinderUI(app)
-    next()
-  }, pathfinderUI.router)
 };
 
 const after = (app) => {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "grunt-shell": "^2.1.0",
     "load-grunt-config": "^0.19.2",
     "mocha": "^3.2.0",
-    "pathfinder-ui": "^1.0.3",
     "supertest": "^2.0.1",
     "time-grunt": "^1.4.0"
   }


### PR DESCRIPTION
The package was installed as a devdependency.  But the code using it
was not conditionalized to be development only.  As a result, the
production deploy did not work.  Removing all use instead of fixing.
Will discuss with team what we want to do.