### PR TITLE
Remove require of dotenv.

### DIFF
--- a/lib/aws-s3-upload.js
+++ b/lib/aws-s3-upload.js
@@ -1,7 +1,5 @@
 'use strict'
 
-require('dotenv').config()
-
 const AWS = require('aws-sdk')
 const s3 = new AWS.S3()
 const fs = require('fs')


### PR DESCRIPTION
Using this fails on the production deployment and it is not needed
anyway.